### PR TITLE
docs(README): fix repo clone URL in Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Located in `system-walkthrough/examples/ai-generated-fastapi/` - demonstrates th
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/claude-code-agents.git
+git clone https://github.com/andlaf-ak/claude-code-agents.git
 cd claude-code-agents
 
 # Install all agents


### PR DESCRIPTION
New users can now copy and paste the quick install command without modification.

(not sure what the change at the end of the doc is supposed to be; I made this PR entirely via the web UI)